### PR TITLE
Fix order matcher algorithm

### DIFF
--- a/contract/src/math.sw
+++ b/contract/src/math.sw
@@ -9,6 +9,14 @@ impl u64 {
         div_result.as_u64().unwrap()
     }
 
+    pub fn mul_div_rounding_up(self, mul_to: u64, div_to: u64) -> u64{
+        let mul_result = U128::from((0, self)) * U128::from((0, mul_to));
+        let div_to = U128::from((0, div_to));
+        let div_result = mul_result / div_to;
+        let add = if div_result * div_to < mul_result {1} else {0};
+        div_result.as_u64().unwrap() + add
+    }
+
     pub fn as_i64(self) -> I64 {
         I64::from(self)
     }

--- a/tests/match_orders.rs
+++ b/tests/match_orders.rs
@@ -66,6 +66,7 @@ async fn open_base_token_order_cancel_test() {
 
     // Проверяем, что у Alice есть 1 BTC после совершения сделки
     assert!(alice.get_asset_balance(&btc.asset_id).await.unwrap() == (1_f64 * 1e8) as u64);
+    assert_eq!(alice.get_asset_balance(&usdc.asset_id).await.unwrap(), 0);
 
     // Проверяем, что у Alice осталось 47,000 USDC после покупки 1 BTC по цене 45,000 USDC
     orderbook
@@ -73,7 +74,7 @@ async fn open_base_token_order_cancel_test() {
         .cancel_order(&alice_order_id)
         .await
         .unwrap();
-    assert!(alice.get_asset_balance(&usdc.asset_id).await.unwrap() == (46000_f64 * 1e6) as u64);
+    assert_eq!(alice.get_asset_balance(&usdc.asset_id).await.unwrap(), (47000_f64 * 1e6) as u64);
     
     // Проверяем, что у Bob есть 0 BTC после продажи
     assert!(bob.get_asset_balance(&btc.asset_id).await.unwrap() == 0);


### PR DESCRIPTION
thread 'match_orders::open_base_token_order_cancel_test' panicked at tests/match_orders.rs:77:5:
assertion `left == right` failed
  left: 46999999980
 right: 47000000000

Still fails but fix it on test code