### PR TITLE
feat: add instance to SDK

### DIFF
--- a/spark-market-sdk/src/lib.rs
+++ b/spark-market-sdk/src/lib.rs
@@ -79,6 +79,10 @@ impl MarketContract {
         }
     }
 
+    pub fn get_instance(&self) -> &Market<WalletUnlocked> {
+        &self.instance
+    }
+
     pub async fn with_account(&self, account: &WalletUnlocked) -> anyhow::Result<Self> {
         Ok(Self {
             instance: self.instance.clone().with_account(account.clone()),


### PR DESCRIPTION
In order to implement the [multicall](https://docs.fuel.network/docs/fuels-rs/calling-contracts/multicalls/) feature when cancelling multiple open orders in a single transaction, it is necessary to add a method that allows the SDK users to get the instance of the `MarketContract`.

By adding this one function, it makes it significantly easier to import the ABI of the market contract.

https://github.com/compolabs/spark-rust-sdk-examples/blob/aa4efc8d98ef51251835e6b5b36b6ff6dd52721b/src/bin/cancel_orders.rs#L49