### PR TITLE
fix: spelling issue in CLI

### DIFF
--- a/spark-cli/src/commands/registry/cli.rs
+++ b/spark-cli/src/commands/registry/cli.rs
@@ -14,7 +14,7 @@ pub(crate) enum RegistryCommands {
     #[clap(short_flag = 'D')]
     Deploy(DeployCommand),
 
-    /// Unegister a market in the market registry contract
+    /// Unregister a market in the market registry contract
     #[clap(short_flag = 'M')]
     Markets(MarketsCommand),
 
@@ -22,7 +22,7 @@ pub(crate) enum RegistryCommands {
     #[clap(short_flag = 'R')]
     Register(RegisterCommand),
 
-    /// Unegister a market in the market registry contract
+    /// Unregister a market in the market registry contract
     #[clap(short_flag = 'U')]
     Unregister(UnregisterCommand),
 }


### PR DESCRIPTION
Fix spelling issue in CLI